### PR TITLE
Updated for Chicken 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+.idea
+*.log
+*.import.scm
+*.link
+*.o
+tmp/
+
+

--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ The default behavior is to log everything to the console in this format:
 ```
 [date/time] [verbosity level] arg1 arg2 ...
 ```
+
+## usage
+
+``` scheme
+(import logger)
+; set your logging level to one of the following
+; 'debug 'info 'warning 'error
+(log-set-verbosity! 'testing)
+; optionally log to a file
+(log-set-output-file! "path/to/log_file.log")
+; log a message
+(log-debug "Here's a debugging message.")
+(log-info "Just an FYI: That thing happened.")
+(log-warning "Something bad happened, but i handled it.")
+(log-error "Something bad happened and I don't feel good.")
+```

--- a/logger.scm
+++ b/logger.scm
@@ -2,12 +2,22 @@
 ;; A simple logging facility
 ;;
 ;; Sample usage:
-;; (use logger)
-;; (log-set-verbosity! 'debug) ;; any of '(error warning info debug)
 ;;
+;; (import logger)
+;; ; set your logging level to one of the following
+;; ; 'debug 'info 'warning 'error
+;; (log-set-verbosity! 'testing)
+;; ; optionally log to a file
+;; (log-set-output-file! "path/to/log_file.log")
+;; ; log a message
+;; (log-debug "Here's a debugging message.")
+;; (log-info "Just an FYI: That thing happened.")
+;; (log-warning "Something bad happened, but i handled it.")
+;; (log-error "Something bad happened and I don't feel good.")
 ;; @author Tom Kwong
 ;; @copyright 2013 All rights reserved
 ;;
+;; Updated to Chicken 5.x Dec 2021 by masukomi
 
 (module logger 
 	(log-debug log-info log-warning log-error
@@ -15,10 +25,14 @@
 	 log-set-logger! 
 	 log-set-output-file!
 	 log-reset-output-port!)
-	
-(import scheme chicken)
-(use srfi-1)
-(use posix)
+
+  (import chicken.base)
+  (import chicken.condition)
+  (import chicken.format)
+  (import chicken.time)
+  (import chicken.time.posix)
+  (import scheme)
+  (import srfi-1)
 
 ;; this private function requires posix
 (define (%current-datetime-string)

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,7 +1,7 @@
-(use srfi-78)
+(import srfi-78)
 (check-set-mode! 'summary)
 
-(use logger)
+(import logger)
 
 ;; test output to console
 (log-set-verbosity! 'debug)


### PR DESCRIPTION
* updated to chicken 5
* added usage examples to README
* improved usage examples in `logger.scm`
* added some of the extensions the compiler generates to the `.gitignore`


⚠️WARNING:
There's still no license in this repo and there's a copyright notice in `logger.scm` 
As a result, legally no-one can use this is their codebases without a license. Technically my cloned repo that this PR is coming from is an unlawful copyright violation.  :/ 

I don't want to have to violate copyright law to use this simple library.
Please add a license. I'd love if this was MIT licensed or something similarly permissive.  Related, in case you're not aware "public domain" is problematic in a number of countries. So you should always offer a license even if you _also_ want to release this into the public domain. 